### PR TITLE
Migrate aws_c_common, aws_c_http & aws_c_io

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -3,11 +3,11 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_checksums:
 - 0.1.14
 c_compiler:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -5,11 +5,11 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_checksums:
 - 0.1.14
 c_compiler:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -3,11 +3,11 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_checksums:
 - 0.1.14
 c_compiler:

--- a/.ci_support/migrations/aws_c_auth0622.yaml
+++ b/.ci_support/migrations/aws_c_auth0622.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-aws_c_auth:
-- 0.6.22
-migrator_ts: 1673599536.7484975

--- a/.ci_support/migrations/aws_c_common089.yaml
+++ b/.ci_support/migrations/aws_c_common089.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_common:
+- 0.8.9
+migrator_ts: 1673680911.2455108

--- a/.ci_support/migrations/aws_c_http073.yaml
+++ b/.ci_support/migrations/aws_c_http073.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  automerge: true
+aws_c_http:
+- 0.7.3
+migrator_ts: 1675172490.116017

--- a/.ci_support/migrations/aws_c_io01314.yaml
+++ b/.ci_support/migrations/aws_c_io01314.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_io:
+- 0.13.14
+migrator_ts: 1673680924.2678478

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,11 +5,11 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_checksums:
 - 0.1.14
 c_compiler:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,11 +5,11 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_checksums:
 - 0.1.14
 c_compiler:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -3,11 +3,11 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_checksums:
 - 0.1.14
 c_compiler:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,11 @@
-{% set name = "aws-c-s3" %}
 {% set version = "0.2.3" %}
 
 package:
-  name: {{ name|lower }}
+  name: aws-c-s3
   version: {{ version }}
 
 source:
-  url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://github.com/awslabs/aws-c-s3/archive/v{{ version }}.tar.gz
   sha256: a00b3c9f319cd1c9aa2c3fa15098864df94b066dcba0deaccbb3caa952d902fe
   patches:
     - 0001-Find-LibCrypto-on-Linux.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Find-LibCrypto-on-Linux.patch
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage("aws-c-s3", max_pin="x.x.x") }}
 


### PR DESCRIPTION
Migrators racing + being pinned to old versions not being ABI-migrated anymore in other parts of the aws-* stack = conflict

(also, I'm impatient after https://github.com/conda-forge/aws-c-mqtt-feedstock/pull/106 & https://github.com/conda-forge/aws-c-auth-feedstock/pull/133)