### PR TITLE
add aws_c_endofapril26.yaml for v0.12.2

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,10 +12,12 @@ jobs:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,6 +11,7 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,7 +5,7 @@ aws_c_cal:
 aws_c_common:
 - 0.12.6
 aws_c_http:
-- 0.10.12
+- 0.10.13
 aws_c_io:
 - 0.26.3
 aws_checksums:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -5,7 +5,7 @@ aws_c_cal:
 aws_c_common:
 - 0.12.6
 aws_c_http:
-- 0.10.12
+- 0.10.13
 aws_c_io:
 - 0.26.3
 aws_checksums:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -5,7 +5,7 @@ aws_c_cal:
 aws_c_common:
 - 0.12.6
 aws_c_http:
-- 0.10.12
+- 0.10.13
 aws_c_io:
 - 0.26.3
 aws_checksums:

--- a/.ci_support/migrations/aws_c_endofapril26.yaml
+++ b/.ci_support/migrations/aws_c_endofapril26.yaml
@@ -1,0 +1,18 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws-c-* (end-of-april'26)
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+  automerge: true
+migrator_ts: 1777397030
+aws_c_event_stream:
+  - '0.7.0'
+aws_c_http:
+  - '0.10.13'
+aws_c_s3:
+  - '0.12.2'
+aws_crt_cpp:
+  - '0.38.3'
+s2n:
+  - '1.7.2'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -9,7 +9,7 @@ aws_c_cal:
 aws_c_common:
 - 0.12.6
 aws_c_http:
-- 0.10.12
+- 0.10.13
 aws_c_io:
 - 0.26.3
 aws_checksums:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -9,7 +9,7 @@ aws_c_cal:
 aws_c_common:
 - 0.12.6
 aws_c_http:
-- 0.10.12
+- 0.10.13
 aws_c_io:
 - 0.26.3
 aws_checksums:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -5,7 +5,7 @@ aws_c_cal:
 aws_c_common:
 - 0.12.6
 aws_c_http:
-- 0.10.12
+- 0.10.13
 aws_c_io:
 - 0.26.3
 aws_checksums:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,16 +23,19 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -109,7 +112,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "aws-c-s3-feedstock"
-version = "3.58.1"  # conda-smithy version used to generate this file
+version = "3.61.2"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/aws-c-s3-feedstock"
 authors = ["@conda-forge/aws-c-s3"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 76348249b4bc305c1a40d089270a5a419f58c03c231b757de0a49a7a234eec76
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Trying to resolve the Not solvable errors on https://conda-forge.org/status/migration/?name=aws_c_endofapril26 - may need to make a new branch for v0.12.12 (starting from commit 2e18d3b094b05d018a39afb97ac8beb94bfa75f4) then edit the target of this pr.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
